### PR TITLE
Add josm_main_presets

### DIFF
--- a/project_list.txt
+++ b/project_list.txt
@@ -3,7 +3,8 @@ boxlocator https://boxlocator.eu/boxlocator_taginfo.json
 hackerspaces_map http://www.technomancy.org/osm-hackerspaces/taginfo.json
 historic_place http://gk.historic.place/taginfo/historic.place.json
 id_editor https://raw.githubusercontent.com/openstreetmap/iD/master/data/taginfo.json
-josm_main_mappaint_style http://josm.openstreetmap.de/download/taginfo/taginfo_style.json
+josm_main_mappaint_style https://josm.openstreetmap.de/download/taginfo/taginfo_style.json
+josm_main_presets https://josm.openstreetmap.de/download/taginfo/taginfo_presets.json
 maxheight_map https://raw.githubusercontent.com/mmd-osm/osm-maxheight-map/master/taginfo.json
 nominatim http://nominatim.openstreetmap.org/taginfo.json
 openbeermap http://openbeermap.github.io/taginfo.json


### PR DESCRIPTION
This adds tags supported by the default presets in the OSM editor JOSM.
See also: https://josm.openstreetmap.de/ticket/10512