### PR TITLE
added taginfo project_id and url for valhalla routing.

### DIFF
--- a/project_list.txt
+++ b/project_list.txt
@@ -24,6 +24,7 @@ scout_rendering https://raw.githubusercontent.com/mvexel/taginfo-scout/master/te
 scout_routing https://raw.githubusercontent.com/mvexel/taginfo-scout/master/telenav_style.json
 townlands_ie http://www.townlands.ie/taginfo.json
 unterkunftskarte http://unterkunftskarte.de/unterkunftskarte.json
+valhalla https://raw.githubusercontent.com/valhalla/conf/master/taginfo.json
 vespucci https://osmeditor4android.googlecode.com/svn/trunk/taginfo.json
 waymarkedtrails http://mapstatic.waymarkedtrails.org/taginfo.json
 wikidata_org http://tools.wmflabs.org/wp-world/wikidata/tags.php


### PR DESCRIPTION
Hello,
We would like to get the osm tags that valhalla supports into taginfo.  
Thanks.

  --Greg.